### PR TITLE
for not existing /number.fomat return 404

### DIFF
--- a/app.py
+++ b/app.py
@@ -1260,8 +1260,14 @@ def crs_text(id, format='', code=''):
           mbbox.append(b)
 
     else:
-      trans_result = code_result
-      url_coords = rcode
+      if code_result:
+        trans_result = code_result
+        url_coords = rcode
+      else:
+        error = 404
+        try_url = ""
+        return render_template('error.html',error=error, try_url=try_url, version=VERSION)
+        
     if not re.findall(r'([a-df-zA-Z_])',values):
       if str(values) != "(0,)" and str(values) != "":
         values = str(values[1:-1]).split(', ')


### PR DESCRIPTION
For a not existing link to `/number.format` e.g. https://epsg.io/38482.wkt return `404` as same as for https://epsg.io/38482